### PR TITLE
添加定时清除过时录像带功能

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,14 @@ plugins {
 }
 
 group = "cn.xor7"
-version = "1.0.3"
+version = "1.0.4"
 
 repositories {
     mavenLocal()
+    maven("https://maven.aliyun.com/repository/public")
     mavenCentral()
     maven("https://oss.sonatype.org/content/groups/public/")
+    maven("https://maven.aliyun.com/repository/public")
     maven("https://repo.leavesmc.top/releases")
     maven("https://repo.leavesmc.top/snapshots")
 }
@@ -50,6 +52,10 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.withType<ShadowJar> {
     minimize()
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    mergeServiceFiles()
 }
 
 kotlin {

--- a/src/main/java/cn/xor7/iseeyou/ConfigData.kt
+++ b/src/main/java/cn/xor7/iseeyou/ConfigData.kt
@@ -3,15 +3,16 @@ package cn.xor7.iseeyou
 import org.bukkit.entity.Player
 
 data class ConfigData(
-    var pauseRecordingOnHighSpeed: HighSpeedPauseConfig = HighSpeedPauseConfig(),
-    var deleteTmpFileOnLoad: Boolean = true,
-    var pauseInsteadOfStopRecordingOnPlayerQuit: Boolean = false,
-    var recordMode: String = "blacklist",
-    var checkBy: String = "name",
-    var recordPath: String = "replay/player/\${name}@\${uuid}",
-    var blacklist: Set<String>? = null,
-    var whitelist: Set<String>? = null,
-    // var asyncSave: Boolean = false,
+        var pauseRecordingOnHighSpeed: HighSpeedPauseConfig = HighSpeedPauseConfig(),
+        var deleteTmpFileOnLoad: Boolean = true,
+        var pauseInsteadOfStopRecordingOnPlayerQuit: Boolean = false,
+        var recordMode: String = "blacklist",
+        var checkBy: String = "name",
+        var recordPath: String = "replay/player/\${name}@\${uuid}",
+        var blacklist: Set<String>? = null,
+        var whitelist: Set<String>? = null,
+        var outdatedRecordRetentionDays: Int = 7,
+        // var asyncSave: Boolean = false,
 ) {
     fun isConfigValid(): String? {
         if ("name" != checkBy && "uuid" != checkBy) {
@@ -51,6 +52,6 @@ data class ConfigData(
 }
 
 data class HighSpeedPauseConfig(
-    var enabled: Boolean = false,
-    var threshold: Double = 20.00,
+        var enabled: Boolean = false,
+        var threshold: Double = 20.00,
 )

--- a/src/main/java/cn/xor7/iseeyou/EventListener.kt
+++ b/src/main/java/cn/xor7/iseeyou/EventListener.kt
@@ -19,9 +19,7 @@ import kotlin.math.pow
  * 事件监听器对象，用于监听玩家加入、移动和退出事件
  */
 object EventListener : Listener {
-    // 日期格式化器，用于格式化日期时间
     private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd@HH-mm-ss")
-    // 高速移动暂停录制的速度阈值，每 tick 的速度阈值的平方
     var pauseRecordingOnHighSpeedThresholdPerTickSquared = 0.00
 
     /**
@@ -102,7 +100,6 @@ object EventListener : Listener {
     fun onPlayerQuit(event: PlayerQuitEvent) {
         val photographer: Photographer = photographers[event.player.uniqueId.toString()] ?: return
         highSpeedPausedPhotographers.remove(photographer)
-        // 如果配置为玩家退出时暂停录制而不是停止录制，则恢复录制
         if (toml!!.data.pauseInsteadOfStopRecordingOnPlayerQuit) {
             photographer.resumeRecording()
         } else {

--- a/src/main/java/cn/xor7/iseeyou/EventListener.kt
+++ b/src/main/java/cn/xor7/iseeyou/EventListener.kt
@@ -32,11 +32,9 @@ object EventListener : Listener {
     fun onPlayerJoin(event: PlayerJoinEvent) {
         val player = event.player
         val playerUniqueId = player.uniqueId.toString()
-        // 如果不需要记录该玩家的行为，则直接返回
         if (!toml!!.data.shouldRecordPlayer(player)) {
             return
         }
-        // 如果配置为玩家退出时暂停录制而不是停止录制，并且该玩家已有摄影师对象，则恢复录制并设置跟随玩家
         if (toml!!.data.pauseInsteadOfStopRecordingOnPlayerQuit && photographers.containsKey(playerUniqueId)) {
             val photographer: Photographer = photographers[playerUniqueId]!!
             photographer.resumeRecording()
@@ -44,22 +42,18 @@ object EventListener : Listener {
             return
         }
         var prefix = player.name
-        // 如果玩家名长度大于 10，则截取前 10 个字符
         if (prefix.length > 10) {
             prefix = prefix.substring(0, 10)
         }
-        // 如果玩家名以 "." 开头，则替换为 "_"
         if (prefix.startsWith(".")) { // fix Floodgate
             prefix = prefix.replace(".", "_")
         }
-        // 创建摄影师对象
         val photographer = Bukkit
                 .getPhotographerManager()
                 .createPhotographer(
                         (prefix + "_" + UUID.randomUUID().toString().replace("-".toRegex(), "")).substring(0, 16),
                         player.location
                 )
-        // 如果创建失败，则抛出异常
         if (photographer == null) {
             throw RuntimeException(
                     "Error on create photographer for player: {name: " + player.name + " , UUID:" + playerUniqueId + "}"
@@ -67,12 +61,10 @@ object EventListener : Listener {
         }
 
         val currentTime = LocalDateTime.now()
-        // 构建录制文件保存路径
         val recordPath: String = toml!!.data.recordPath
                 .replace("\${name}", player.name)
                 .replace("\${uuid}", playerUniqueId)
         File(recordPath).mkdirs()
-        // 创建录制文件
         val recordFile = File(recordPath + "/" + currentTime.format(DATE_FORMATTER) + ".mcpr")
         if (recordFile.exists()) {
             recordFile.delete()
@@ -91,7 +83,6 @@ object EventListener : Listener {
     fun onPlayerMove(event: PlayerMoveEvent) {
         val photographer: Photographer = photographers[event.player.uniqueId.toString()]!!
         val velocity = event.player.velocity
-        // 如果配置为启用高速移动暂停录制，并且玩家速度超过阈值，则暂停录制
         if (toml!!.data.pauseRecordingOnHighSpeed.enabled &&
                 velocity.x.pow(2.0) + velocity.z.pow(2.0) > pauseRecordingOnHighSpeedThresholdPerTickSquared &&
                 !highSpeedPausedPhotographers.contains(photographer)
@@ -99,7 +90,6 @@ object EventListener : Listener {
             photographer.pauseRecording()
             highSpeedPausedPhotographers.add(photographer)
         }
-        // 恢复录制并设置跟随玩家
         photographer.resumeRecording()
         photographer.setFollowPlayer(event.player)
         highSpeedPausedPhotographers.remove(photographer)
@@ -116,7 +106,6 @@ object EventListener : Listener {
         if (toml!!.data.pauseInsteadOfStopRecordingOnPlayerQuit) {
             photographer.resumeRecording()
         } else {
-            // 否则停止录制并移除摄影师对象
             photographer.stopRecording()
             photographers.remove(event.player.uniqueId.toString())
         }

--- a/src/main/java/cn/xor7/iseeyou/EventListener.kt
+++ b/src/main/java/cn/xor7/iseeyou/EventListener.kt
@@ -15,18 +15,28 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlin.math.pow
 
+/**
+ * 事件监听器对象，用于监听玩家加入、移动和退出事件
+ */
 object EventListener : Listener {
+    // 日期格式化器，用于格式化日期时间
     private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd@HH-mm-ss")
+    // 高速移动暂停录制的速度阈值，每 tick 的速度阈值的平方
     var pauseRecordingOnHighSpeedThresholdPerTickSquared = 0.00
 
+    /**
+     * 监听玩家加入事件
+     */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     @Throws(IOException::class)
     fun onPlayerJoin(event: PlayerJoinEvent) {
         val player = event.player
         val playerUniqueId = player.uniqueId.toString()
+        // 如果不需要记录该玩家的行为，则直接返回
         if (!toml!!.data.shouldRecordPlayer(player)) {
             return
         }
+        // 如果配置为玩家退出时暂停录制而不是停止录制，并且该玩家已有摄影师对象，则恢复录制并设置跟随玩家
         if (toml!!.data.pauseInsteadOfStopRecordingOnPlayerQuit && photographers.containsKey(playerUniqueId)) {
             val photographer: Photographer = photographers[playerUniqueId]!!
             photographer.resumeRecording()
@@ -34,29 +44,35 @@ object EventListener : Listener {
             return
         }
         var prefix = player.name
+        // 如果玩家名长度大于 10，则截取前 10 个字符
         if (prefix.length > 10) {
             prefix = prefix.substring(0, 10)
         }
+        // 如果玩家名以 "." 开头，则替换为 "_"
         if (prefix.startsWith(".")) { // fix Floodgate
             prefix = prefix.replace(".", "_")
         }
+        // 创建摄影师对象
         val photographer = Bukkit
-            .getPhotographerManager()
-            .createPhotographer(
-                (prefix + "_" + UUID.randomUUID().toString().replace("-".toRegex(), "")).substring(0, 16),
-                player.location
-            )
+                .getPhotographerManager()
+                .createPhotographer(
+                        (prefix + "_" + UUID.randomUUID().toString().replace("-".toRegex(), "")).substring(0, 16),
+                        player.location
+                )
+        // 如果创建失败，则抛出异常
         if (photographer == null) {
             throw RuntimeException(
-                "Error on create photographer for player: {name: " + player.name + " , UUID:" + playerUniqueId + "}"
+                    "Error on create photographer for player: {name: " + player.name + " , UUID:" + playerUniqueId + "}"
             )
         }
 
         val currentTime = LocalDateTime.now()
+        // 构建录制文件保存路径
         val recordPath: String = toml!!.data.recordPath
-            .replace("\${name}", player.name)
-            .replace("\${uuid}", playerUniqueId)
+                .replace("\${name}", player.name)
+                .replace("\${uuid}", playerUniqueId)
         File(recordPath).mkdirs()
+        // 创建录制文件
         val recordFile = File(recordPath + "/" + currentTime.format(DATE_FORMATTER) + ".mcpr")
         if (recordFile.exists()) {
             recordFile.delete()
@@ -68,30 +84,39 @@ object EventListener : Listener {
         photographer.setFollowPlayer(player)
     }
 
+    /**
+     * 监听玩家移动事件
+     */
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
         val photographer: Photographer = photographers[event.player.uniqueId.toString()]!!
         val velocity = event.player.velocity
+        // 如果配置为启用高速移动暂停录制，并且玩家速度超过阈值，则暂停录制
         if (toml!!.data.pauseRecordingOnHighSpeed.enabled &&
-            velocity.x.pow(2.0) + velocity.z.pow(2.0) > pauseRecordingOnHighSpeedThresholdPerTickSquared &&
-            !highSpeedPausedPhotographers.contains(photographer)
+                velocity.x.pow(2.0) + velocity.z.pow(2.0) > pauseRecordingOnHighSpeedThresholdPerTickSquared &&
+                !highSpeedPausedPhotographers.contains(photographer)
         ) {
             photographer.pauseRecording()
             highSpeedPausedPhotographers.add(photographer)
         }
+        // 恢复录制并设置跟随玩家
         photographer.resumeRecording()
         photographer.setFollowPlayer(event.player)
         highSpeedPausedPhotographers.remove(photographer)
     }
 
+    /**
+     * 监听玩家退出事件
+     */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     fun onPlayerQuit(event: PlayerQuitEvent) {
         val photographer: Photographer = photographers[event.player.uniqueId.toString()] ?: return
         highSpeedPausedPhotographers.remove(photographer)
+        // 如果配置为玩家退出时暂停录制而不是停止录制，则恢复录制
         if (toml!!.data.pauseInsteadOfStopRecordingOnPlayerQuit) {
             photographer.resumeRecording()
         } else {
-            // photographer.stopRecording(toml!!.data.asyncSave)
+            // 否则停止录制并移除摄影师对象
             photographer.stopRecording()
             photographers.remove(event.player.uniqueId.toString())
         }

--- a/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
+++ b/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
@@ -1,15 +1,16 @@
 package cn.xor7.iseeyou
 
+
 import org.bukkit.Bukkit
+import org.bukkit.command.CommandExecutor
 import org.bukkit.plugin.java.JavaPlugin
 import top.leavesmc.leaves.entity.Photographer
 import java.io.IOException
 import java.nio.file.*
-import java.util.*
 import java.nio.file.attribute.BasicFileAttributes
 import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
+import java.util.*
 import kotlin.io.path.isDirectory
 import kotlin.math.pow
 
@@ -19,7 +20,7 @@ var highSpeedPausedPhotographers = mutableSetOf<Photographer>()
 var outdatedRecordRetentionDays: Int = 0
 
 @Suppress("unused")
-class ISeeYou : JavaPlugin() {
+class ISeeYou : JavaPlugin(), CommandExecutor {
     override fun onEnable() {
         setupConfig()
         if (toml != null) {
@@ -132,4 +133,5 @@ class ISeeYou : JavaPlugin() {
         }
         return deletedCount
     }
+
 }

--- a/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
+++ b/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
@@ -111,7 +111,7 @@ class ISeeYou : JavaPlugin() {
                 paths.filter { Files.isRegularFile(it) && it.toString().endsWith(".mcpr") }
                         .forEach { file ->
                             val fileName = file.fileName.toString()
-                            val creationDateStr = fileName.substringBefore('@') // 从文件名中提取创建日期部分
+                            val creationDateStr = fileName.substringBefore('@')
                             val creationDate = LocalDate.parse(creationDateStr)
                             val daysSinceCreation = Duration.between(creationDate.atStartOfDay(), currentDate.atStartOfDay()).toDays()
                             if (daysSinceCreation > outdatedRecordRetentionDays) {

--- a/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
+++ b/src/main/java/cn/xor7/iseeyou/ISeeYou.kt
@@ -5,31 +5,41 @@ import org.bukkit.plugin.java.JavaPlugin
 import top.leavesmc.leaves.entity.Photographer
 import java.io.IOException
 import java.nio.file.*
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.*
+import java.nio.file.attribute.BasicFileAttributes
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
 import kotlin.io.path.isDirectory
 import kotlin.math.pow
 
 var toml: TomlEx<ConfigData>? = null
 var photographers = mutableMapOf<String, Photographer>()
 var highSpeedPausedPhotographers = mutableSetOf<Photographer>()
+var outdatedRecordRetentionDays: Int = 0
 
 @Suppress("unused")
 class ISeeYou : JavaPlugin() {
     override fun onEnable() {
         setupConfig()
-        if (toml!!.data.deleteTmpFileOnLoad) {
-            try {
-                Files.walk(Paths.get("replay/"), Int.MAX_VALUE, FileVisitOption.FOLLOW_LINKS).use { paths ->
-                    paths.filter { it.isDirectory() && it.fileName.toString().endsWith(".tmp") }
-                        .forEach { deleteTmpFolder(it) }
+        if (toml != null) {
+            if (toml!!.data.deleteTmpFileOnLoad) {
+                try {
+                    Files.walk(Paths.get(toml!!.data.recordPath), Int.MAX_VALUE, FileVisitOption.FOLLOW_LINKS).use { paths ->
+                        paths.filter { it.isDirectory() && it.fileName.toString().endsWith(".tmp") }
+                                .forEach { deleteTmpFolder(it) }
+                    }
+                } catch (_: IOException) {
                 }
-            } catch (_: IOException) {
             }
+            EventListener.pauseRecordingOnHighSpeedThresholdPerTickSquared =
+                    (toml!!.data.pauseRecordingOnHighSpeed.threshold / 20).pow(2.0)
+            cleanOutdatedRecordings()
+            Bukkit.getPluginManager().registerEvents(EventListener, this)
+        } else {
+            logger.warning("Failed to initialize configuration. Plugin will not enable.")
+            Bukkit.getPluginManager().disablePlugin(this)
         }
-        EventListener.pauseRecordingOnHighSpeedThresholdPerTickSquared =
-            (toml!!.data.pauseRecordingOnHighSpeed.threshold / 20).pow(2.0)
-        Bukkit.getPluginManager().registerEvents(EventListener, this)
     }
 
     private fun setupConfig() {
@@ -39,6 +49,7 @@ class ISeeYou : JavaPlugin() {
             throw Error(errMsg)
         }
         toml!!.data.setConfig()
+        outdatedRecordRetentionDays = toml!!.data.outdatedRecordRetentionDays
         toml!!.save()
     }
 
@@ -53,24 +64,72 @@ class ISeeYou : JavaPlugin() {
     private fun deleteTmpFolder(folderPath: Path) {
         try {
             Files.walkFileTree(
-                folderPath,
-                EnumSet.noneOf(FileVisitOption::class.java),
-                Int.MAX_VALUE,
-                object : SimpleFileVisitor<Path>() {
-                    @Throws(IOException::class)
-                    override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-                        Files.delete(file)
-                        return FileVisitResult.CONTINUE
-                    }
+                    folderPath,
+                    EnumSet.noneOf(FileVisitOption::class.java),
+                    Int.MAX_VALUE,
+                    object : SimpleFileVisitor<Path>() {
+                        @Throws(IOException::class)
+                        override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                            Files.delete(file)
+                            return FileVisitResult.CONTINUE
+                        }
 
-                    @Throws(IOException::class)
-                    override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
-                        Files.delete(dir)
-                        return FileVisitResult.CONTINUE
-                    }
-                })
+                        @Throws(IOException::class)
+                        override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+                            Files.delete(dir)
+                            return FileVisitResult.CONTINUE
+                        }
+                    })
         } catch (e: IOException) {
             e.printStackTrace()
         }
+    }
+
+    private fun cleanOutdatedRecordings() {
+        try {
+            val recordingsDir = Paths.get(".")
+            logger.info("Start to delete outdated recordings in $recordingsDir")
+            var deletedCount = 0
+            Files.walk(recordingsDir).use { paths ->
+                paths.filter { Files.isDirectory(it) && it.parent == recordingsDir }
+                        .forEach { folder ->
+                            deletedCount += deleteRecordingFiles(folder)
+                        }
+            }
+            logger.info("Finished deleting outdated recordings in $recordingsDir, deleted $deletedCount files")
+        } catch (e: IOException) {
+            logger.severe("Error occurred while cleaning outdated recordings: ${e.message}")
+            e.printStackTrace()
+        }
+    }
+
+    private fun deleteRecordingFiles(folderPath: Path): Int {
+        var deletedCount = 0
+        try {
+            val currentDate = LocalDate.now()
+            Files.walk(folderPath).use { paths ->
+                paths.filter { Files.isRegularFile(it) && it.toString().endsWith(".mcpr") }
+                        .forEach { file ->
+                            val fileName = file.fileName.toString()
+                            val creationDateStr = fileName.substringBefore('@') // 从文件名中提取创建日期部分
+                            val creationDate = LocalDate.parse(creationDateStr)
+                            val daysSinceCreation = Duration.between(creationDate.atStartOfDay(), currentDate.atStartOfDay()).toDays()
+                            if (daysSinceCreation > outdatedRecordRetentionDays) {
+                                try {
+                                    Files.delete(file)
+                                    logger.info("Deleted recording file: $fileName")
+                                    deletedCount++
+                                } catch (e: IOException) {
+                                    logger.severe("Error occurred while deleting recording file: $fileName, Error: ${e.message}")
+                                    e.printStackTrace()
+                                }
+                            }
+                        }
+            }
+        } catch (e: IOException) {
+            logger.severe("Error occurred while processing recording files in folder: $folderPath, Error: ${e.message}")
+            e.printStackTrace()
+        }
+        return deletedCount
     }
 }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,5 @@ name: ISeeYou
 version: ${version}
 main: cn.xor7.iseeyou.ISeeYou
 api-version: '1.20'
+
+


### PR DESCRIPTION
## PR日志
### 新增
1.定时清除过时录像带功能，配置项outdatedRecordRetentionDays（默认值为7）
### 缺陷
1./icu clean指令，当前仅在插件启用的时候会清理一次过时录像
2.路径不完全准确，当前是在服务端目录下查找过时.mcpr文件