### PR TITLE
1.21.8支持

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 group = "cn.xor7"
 version = "1.3.7"
 
-val commandAPIVer = "10.0.1"
+val commandAPIVer = "10.1.2"
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
更新 CommandAPI 至 10.1.2 以支持 Minecraft 1.21.8
*已进行粗略测试, 正常录制玩家没有问题